### PR TITLE
Change allure plugin output in default profile

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,1 +1,1 @@
-default: "--format pretty --color --format AllureCucumber::CucumberFormatter --out report/allure-results"
+default: "--format pretty --color --format AllureCucumber::CucumberFormatter --out report/strange-folder"


### PR DESCRIPTION
Steps to reproduce:

1. update cucumber.yml
```yaml
default: "--format pretty --color --format AllureCucumber::CucumberFormatter --out report/strange-folder"
```
2. run tests
3. check reports folder

Expected : overrided results directory with allure files should exist: `reports/strange-folder`

Actual: results directory specified in `AllureCucumber.configure` is used `reports/allure-results`

proof:
```bash
➜  allure-cucumber-example git:(master) ✗ ls
Gemfile      Gemfile.lock README.md    config       features

➜  allure-cucumber-example git:(master) ✗ bundle exec cucumber
Using the default profile...
Feature: Using Google

<omitted for brevity>

➜  allure-cucumber-example git:(master) ✗ ls
Gemfile      Gemfile.lock README.md    config       features     report

➜  allure-cucumber-example git:(master) ✗ ls report
allure-results

```